### PR TITLE
Kafka and mqtt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,25 @@
-.PHONY: up down logs test clean
+.PHONY: up up-kafka up-mqtt down logs test clean
+
+BROKER_BACKEND ?= kafka
+COMPOSE_PROFILES ?= $(BROKER_BACKEND)
 
 up:
-	docker-compose up -d --build
+	BROKER_BACKEND=$(BROKER_BACKEND) COMPOSE_PROFILES=$(COMPOSE_PROFILES) docker compose up -d --build
+
+up-kafka:
+	BROKER_BACKEND=kafka COMPOSE_PROFILES=kafka docker compose up -d --build
+
+up-mqtt:
+	BROKER_BACKEND=mqtt COMPOSE_PROFILES=mqtt docker compose up -d --build
 
 down:
-	docker-compose down
+	docker compose down
 
 logs:
-	docker-compose logs -f
+	docker compose logs -f
 
 test:
-	docker exec $$(docker-compose psq kafka | tail -1 | awk '{print $$1}') \
-		kafka-console-producer --bootstrap-server localhost:9092 --topic input-messages \
-		<<< '{"id": "test", "drone_id": "SITL-001", "type": "HEARTBEAT"}'
+	BROKER_BACKEND=$(BROKER_BACKEND) COMPOSE_PROFILES=$(COMPOSE_PROFILES) docker compose run --rm --no-deps verifier pytest -q tests
 
 clean:
 	docker compose down --volumes --remove-orphans

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
-  # --- Infrastructure ---
   zookeeper:
+    profiles: ["kafka"]
     image: confluentinc/cp-zookeeper:7.5.0
     container_name: sitl-zookeeper
     environment:
@@ -13,6 +13,7 @@ services:
       retries: 5
 
   kafka:
+    profiles: ["kafka"]
     image: confluentinc/cp-kafka:7.5.0
     container_name: sitl-kafka
     depends_on:
@@ -35,6 +36,20 @@ services:
       timeout: 10s
       retries: 5
 
+  mosquitto:
+    profiles: ["mqtt"]
+    image: eclipse-mosquitto:2.0
+    container_name: sitl-mosquitto
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+    healthcheck:
+      test: ["CMD", "mosquitto_sub", "-h", "localhost", "-p", "1883", "-t", "$$SYS/broker/version", "-C", "1", "-W", "5"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+
   redis:
     image: redis:7-alpine
     container_name: sitl-redis
@@ -49,23 +64,25 @@ services:
       timeout: 5s
       retries: 5
 
-  # --- Application Services ---
   verifier:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: sitl-verifier
     command: ["python", "-u", "src/verifier.py"]
-    depends_on:
-      kafka:
-        condition: service_healthy
     environment:
-      KAFKA_SERVERS: kafka:29092
-      INPUT_TOPICS: "sitl.commands,sitl-drone-home"
-      COMMAND_TOPIC: sitl.commands
-      HOME_TOPIC: sitl-drone-home
-      VERIFIED_COMMAND_TOPIC: sitl.verified-commands
-      VERIFIED_HOME_TOPIC: sitl.verified-home
+      BROKER_BACKEND: ${BROKER_BACKEND:-kafka}
+      KAFKA_SERVERS: ${KAFKA_SERVERS:-kafka:29092}
+      MQTT_HOST: ${MQTT_HOST:-mosquitto}
+      MQTT_PORT: ${MQTT_PORT:-1883}
+      MQTT_USERNAME: ${MQTT_USERNAME:-}
+      MQTT_PASSWORD: ${MQTT_PASSWORD:-}
+      MQTT_QOS: ${MQTT_QOS:-1}
+      INPUT_TOPICS: ${INPUT_TOPICS:-sitl.commands,sitl-drone-home}
+      COMMAND_TOPIC: ${COMMAND_TOPIC:-sitl.commands}
+      HOME_TOPIC: ${HOME_TOPIC:-sitl-drone-home}
+      VERIFIED_COMMAND_TOPIC: ${VERIFIED_COMMAND_TOPIC:-sitl.verified-commands}
+      VERIFIED_HOME_TOPIC: ${VERIFIED_HOME_TOPIC:-sitl.verified-home}
     restart: unless-stopped
 
   controller:
@@ -75,16 +92,20 @@ services:
     container_name: sitl-controller
     command: ["python", "-u", "src/controller.py"]
     depends_on:
-      kafka:
-        condition: service_healthy
       redis:
         condition: service_healthy
     environment:
-      KAFKA_SERVERS: kafka:29092
-      REDIS_URL: redis://redis:6379
-      VERIFIED_COMMAND_TOPIC: sitl.verified-commands
-      VERIFIED_HOME_TOPIC: sitl.verified-home
-      STATE_TTL_SEC: "7200"
+      BROKER_BACKEND: ${BROKER_BACKEND:-kafka}
+      KAFKA_SERVERS: ${KAFKA_SERVERS:-kafka:29092}
+      MQTT_HOST: ${MQTT_HOST:-mosquitto}
+      MQTT_PORT: ${MQTT_PORT:-1883}
+      MQTT_USERNAME: ${MQTT_USERNAME:-}
+      MQTT_PASSWORD: ${MQTT_PASSWORD:-}
+      MQTT_QOS: ${MQTT_QOS:-1}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      VERIFIED_COMMAND_TOPIC: ${VERIFIED_COMMAND_TOPIC:-sitl.verified-commands}
+      VERIFIED_HOME_TOPIC: ${VERIFIED_HOME_TOPIC:-sitl.verified-home}
+      STATE_TTL_SEC: ${STATE_TTL_SEC:-7200}
     restart: unless-stopped
 
   core:
@@ -97,9 +118,9 @@ services:
       redis:
         condition: service_healthy
     environment:
-      REDIS_URL: redis://redis:6379
-      UPDATE_FREQUENCY_HZ: "10.0"
-      STATE_TTL_SEC: "7200"
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      UPDATE_FREQUENCY_HZ: ${UPDATE_FREQUENCY_HZ:-10.0}
+      STATE_TTL_SEC: ${STATE_TTL_SEC:-7200}
     restart: unless-stopped
 
   messaging:
@@ -109,15 +130,19 @@ services:
     container_name: sitl-messaging
     command: ["python", "-u", "src/messaging.py"]
     depends_on:
-      kafka:
-        condition: service_healthy
       redis:
         condition: service_healthy
     environment:
-      KAFKA_SERVERS: kafka:29092
-      REDIS_URL: redis://redis:6379
-      POSITION_REQUEST_TOPIC: sitl.telemetry.request
-      POSITION_RESPONSE_TOPIC: sitl.telemetry.response
+      BROKER_BACKEND: ${BROKER_BACKEND:-kafka}
+      KAFKA_SERVERS: ${KAFKA_SERVERS:-kafka:29092}
+      MQTT_HOST: ${MQTT_HOST:-mosquitto}
+      MQTT_PORT: ${MQTT_PORT:-1883}
+      MQTT_USERNAME: ${MQTT_USERNAME:-}
+      MQTT_PASSWORD: ${MQTT_PASSWORD:-}
+      MQTT_QOS: ${MQTT_QOS:-1}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      POSITION_REQUEST_TOPIC: ${POSITION_REQUEST_TOPIC:-sitl.telemetry.request}
+      POSITION_RESPONSE_TOPIC: ${POSITION_RESPONSE_TOPIC:-sitl.telemetry.response}
     restart: unless-stopped
 
 volumes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,135 +1,176 @@
-# Алгоритм работы SITL-адаптера
+# Архитектура SITL-модуля
 
-## 1. Схема жизненного цикла данных (Data Flow)
-Дрон в SITL-адаптере проходит **три стадии состояния**:
+## Кратко
 
-**IDLE** (Ожидание): Дрон известен системе, но у него нет точки HOME. Команды движения игнорируются.  
-**ARMED** (Готов): Получено сообщение в `sitl-drone-home`. Координаты записаны в Redis. Адаптер начинает транслировать NMEA с нулевой скоростью.  
-**MOVING** (Движение): Получена команда в `sitl-commands`. Адаптер обновляет вектор скорости в Redis и в каждом тике (10 Гц) пересчитывает координаты.
+Система состоит из четырех приложений:
 
- Как работает: Listener мониторит MQTT-топики. При sitl-drone-home делает HSET drone:001:state home_lat 59.9 home_lon 30.3 status "ARMED". При sitl-commands с скоростями vx²+vy²>0.01 меняет status "MOVING". Ticker проверяет статус: если MOVING — применяет физику, иначе статично транслирует HOME с v=0.
- 
-## 2. Структура хранения в Redis (Data Schema)
-Для обеспечения скорости 10 Гц на 100 дронов используйте тип данных **Hash**. Это позволит обновлять параметры мгновенно без перепарсинга JSON.  
-**Ключ**: `drone:{drone_id}:state`  
-**Поля (Fields)**:
-```
-lat, lon, alt — текущие географические координаты (float)
-vx, vy, vz — текущие скорости в м/с (извлекаются из команд привода)
-speed_h_ms — горизонтальная скорость √(vx²+vy²) (float, вычисляется в ticker)
-speed_v_ms — вертикальная скорость |vz| (float, вычисляется в ticker)
-heading — курс (degrees)
-home_lat, home_lon, home_alt — зафиксированная точка взлета
-last_update — timestamp последнего изменения вектора скорости (string)
-```
- Как работает: Listener использует атомарный HSET — 1 команда меняет 5 полей (vx,vy,vz,heading,last_update). Ticker читает HGETALL (15 полей за 0.1мс), вычисляет speed_h_ms=math.sqrt(vx*vx+vy*vy) и speed_v_ms=abs(vz), записывает обратно HSET pipeline (атомарно для 100 дронов).
- 
-## 3. Алгоритм работы Адаптера (Main Loop)
-Адаптер должен состоять из **двух параллельных процессов (или асинхронных задач)**:
+- `verifier`
+- `controller`
+- `core`
+- `messaging`
 
-**Поток А: Приемник (Listener)**  
-Слушает MQTT топики `sitl.commands` и `sitl-drone-home`.  
-При получении команды — просто делает **HSET** в Redis для соответствующего `drone_id`. Никаких расчетов здесь не делается.
+И двух инфраструктурных зависимостей:
 
-**Поток Б: Вычислитель (Ticker 10 Hz)**  
-Каждые 100мс обновить координаты всех активных дронов по скоростям из Redis.
+- Redis для хранения текущего состояния дронов
+- брокер сообщений, который выбирается через `BROKER_BACKEND=kafka|mqtt`
 
-## JSON схемы для сообщений SITL
+За один запуск активен ровно один брокер. Topic names одинаковы для Kafka и MQTT, меняется только транспорт.
 
-### Общие принципы
-- Изоляция — каждая схема для конкретного топика Kafka/MQTT
-- Контроль взаимодействия — строгая валидация входных/выходных данных
-- Минимализация доверенной базы — stateless валидация в `verificator.py`
-- Контейнеризация — схемы в `schemas/` как Volume в Docker
+## Поток данных
 
-### Базовые принципы (интерпретация для SITL)
-- Взаимодействие только через брокер сообщений (`sitl.commands`, `sitl-drone-home`)
-- Выдача событий безопасности по запросу через REST API
-- Передача телеметрии в сервис аналитики (`sitl.telemetry`)
-- Передача событий безопасности в сервис аналитики (`sitl.safety-events`)
-- События записываются в журнал с `msg_id + timestamp`
+### 1. Входные сообщения
 
-## 1. Схема входных команд от Приводов
-**Топик**: `sitl.commands`
-```json
-{
-  "type": "object",
-  "required": ["drone_id", "vx", "vy", "vz", "mag_heading"],
-  "properties": {
-    "drone_id": {"type": "string", "pattern": "^drone_[0-9]{3,4}$"},
-    "vx": {"type": "number", "minimum": -50, "maximum": 50},
-    "vy": {"type": "number", "minimum": -50, "maximum": 50},
-    "vz": {"type": "number", "minimum": -10, "maximum": 10},
-    "mag_heading": {"type": "number", "minimum": 0, "maximum": 359.9}
-  }
-}
+В систему поступают два типа входных сообщений:
+
+- `sitl.commands`
+- `sitl-drone-home`
+
+`verifier` читает эти сообщения из выбранного брокера, валидирует JSON по схемам из `schemas/` и публикует результат в:
+
+- `sitl.verified-commands`
+- `sitl.verified-home`
+
+### 2. Состояние дрона
+
+`controller` читает verified-topic'и из выбранного брокера и хранит состояние в Redis по ключу:
+
+```text
+drone:{drone_id}:state
 ```
 
-## 2. Схема HOME позиции (только trusted)
-**Топик**: `sitl-drone-home`
-```json
-{
-  "type": "object",
-  "required": ["drone_id", "home_lat", "home_lon", "home_alt"],
-  "properties": {
-    "drone_id": {"type": "string", "pattern": "^drone_[0-9]{3,4}$"},
-    "home_lat": {"type": "number"},
-    "home_lon": {"type": "number"},
-    "home_alt": {"type": "number"}
-  }
-}
+Поведение:
 
+- HOME создает или обновляет базовое состояние дрона
+- COMMAND без HOME игнорируется
+- COMMAND с ненулевой скоростью переводит дрон в `MOVING`
+- COMMAND с нулевой скоростью возвращает дрон в `ARMED`
+
+### 3. Обновление позиции
+
+`core` не зависит от брокера. Он работает только с Redis:
+
+- ищет ключи `drone:*:state`
+- двигает только дроны со статусом `MOVING`
+- обновляет `lat`, `lon`, `alt`
+- продлевает TTL состояния
+
+Расчет позиции упрощенный и работает по векторам `vx`, `vy`, `vz`.
+
+### 4. Запрос позиции
+
+`messaging` принимает request-сообщения из `sitl.telemetry.request` и отвечает в `reply_to`.
+
+Запрос:
+
+- обязательно содержит `drone_id`
+- может содержать `reply_to`
+- может содержать `correlation_id`
+
+Ответ:
+
+- содержит `lat`, `lon`, `alt`
+- может содержать `correlation_id`
+
+Особенность транспорта:
+
+- в Kafka `correlation_id` дублируется и в payload, и в headers
+- в MQTT transport metadata передается только в payload
+
+## Выбор брокера
+
+### Kafka
+
+Для Kafka используются:
+
+- `zookeeper`
+- `kafka`
+
+Основные env:
+
+- `BROKER_BACKEND=kafka`
+- `KAFKA_SERVERS=kafka:29092`
+
+### MQTT
+
+Для MQTT используется:
+
+- `mosquitto`
+
+Основные env:
+
+- `BROKER_BACKEND=mqtt`
+- `MQTT_HOST=mosquitto`
+- `MQTT_PORT=1883`
+- `MQTT_USERNAME`
+- `MQTT_PASSWORD`
+- `MQTT_QOS=1`
+
+## Сервисы
+
+### verifier
+
+Ответственность:
+
+- принять raw message
+- определить тип сообщения по topic
+- провалидировать payload по JSON Schema
+- перепубликовать payload в verified-topic
+
+### controller
+
+Ответственность:
+
+- принять validated message
+- создать HOME state
+- применить COMMAND к существующему state
+- сохранить state в Redis
+
+### core
+
+Ответственность:
+
+- периодически проходить по Redis state
+- пересчитывать позицию движущихся дронов
+- обновлять время последнего изменения
+
+### messaging
+
+Ответственность:
+
+- обработать запрос позиции
+- достать состояние из Redis
+- сформировать ответ
+- отправить ответ в `reply_to` или в `POSITION_RESPONSE_TOPIC`
+
+## Конфигурация
+
+Общие topic env:
+
+- `COMMAND_TOPIC`
+- `HOME_TOPIC`
+- `VERIFIED_COMMAND_TOPIC`
+- `VERIFIED_HOME_TOPIC`
+- `POSITION_REQUEST_TOPIC`
+- `POSITION_RESPONSE_TOPIC`
+
+Общие runtime env:
+
+- `REDIS_URL`
+- `STATE_TTL_SEC`
+- `UPDATE_FREQUENCY_HZ`
+
+## Docker Compose
+
+Compose использует профили:
+
+- `COMPOSE_PROFILES=kafka` поднимает Kafka-стек
+- `COMPOSE_PROFILES=mqtt` поднимает Mosquitto
+
+Примеры запуска:
+
+```bash
+make up-kafka
+make up-mqtt
 ```
 
-## 3. Схема состояния в Redis (drone:{drone_id}:state)
-**Тип данных**: Hash (HSET/HGETALL)
-```
-Ключ: drone:drone_001:state
-
-status: "IDLE"           # IDLE|ARMED|MOVING|EMERGENCY
-lat: 59.938623           # текущая широта (float)
-lon: 30.316534           # текущая долгота (float) 
-alt: 100.0               # высота м (float)
-vx: 1.23                 # скорость Восток м/с ENU (float)
-vy: 0.87                 # скорость Север м/с ENU (float)
-vz: 0.0                  # скорость вверх м/с (float)
-mag_heading: 25.8        # магнитный курс градусов (float)
-home_lat: 59.938623      # HOME широта (float)
-home_lon: 30.316534      # HOME долгота (float)
-home_alt: 100.0          # HOME высота (float)
-last_update: "2026-03-12T21:35:00Z"  # ISO timestamp (string)
-
-```
- 
-## 4. Запрос телеметрии в SITL-адаптере:
-Запрос в sitl.telemetry.request: (дрон -> SITL)
-```
-Content-Type: application.json
-
-{
-  "drone_id": ["drone_001"]
-}
-
-```
-Ответ (SITL -> дрон)
-```
-{
-    "lat": 59.938623,
-    "lon": 30.316534,
-    "alt": 100.2,
-}
-
-```
-
-## 5. Архитектура
-**Каждая папка — отдельный контейнер**:
-```
-sitl-adapter/
-├── schemas/
-│   ├── sitl-commands.json
-│   └── sitl-drone-home.json
-├── verificator.py          # Stateless JSON Schema валидация
-├── core.py                 # Ticker: физика + NMEA генератор + speed_h_ms, speed_v_ms
-├── controller.py           # Listener: MQTT → Redis HSET
-└── api-server.py           # REST API для safety-events и состояния
-```
+Сами приложения не завязаны на `depends_on` брокера. Вместо этого они повторяют попытки подключения с backoff, пока выбранный брокер не станет доступен.

--- a/docs/MANUAL_TESTS.md
+++ b/docs/MANUAL_TESTS.md
@@ -1,0 +1,305 @@
+# Ручные тесты для Kafka и MQTT
+
+Этот документ проверяет актуальный pipeline:
+
+- `verifier` принимает raw-сообщения и публикует verified-сообщения
+- `controller` обновляет состояние дрона в Redis
+- `core` двигает дрон в Redis с частотой 10 Гц
+- `messaging` отвечает текущей позицией в `reply_to`
+
+Во всех сценариях используются текущие topic names:
+
+- `sitl.commands`
+- `sitl-drone-home`
+- `sitl.verified-commands`
+- `sitl.verified-home`
+- `sitl.telemetry.request`
+- `sitl.telemetry.response`
+
+## Общая подготовка
+
+Очистить стек:
+
+```bash
+docker compose down --volumes --remove-orphans
+```
+
+Проверить состояние контейнеров:
+
+```bash
+docker compose ps -a
+```
+
+Открыть логи приложений:
+
+```bash
+docker compose logs -f verifier controller core messaging
+```
+
+## Kafka-профиль
+
+### Запуск
+
+```bash
+make up-kafka
+```
+
+Ожидаемый результат:
+
+- `sitl-zookeeper` в статусе `Up (healthy)`
+- `sitl-kafka` в статусе `Up (healthy)`
+- `sitl-redis` в статусе `Up (healthy)`
+- `sitl-verifier`, `sitl-controller`, `sitl-core`, `sitl-messaging` в статусе `Up`
+
+### Тест 1. HOME проходит через verifier и попадает в Redis
+
+Терминал 1:
+
+```bash
+docker compose exec kafka kafka-console-consumer --bootstrap-server kafka:29092 --topic sitl.verified-home --consumer-property auto.offset.reset=latest
+```
+
+Терминал 2:
+
+```bash
+docker compose exec -T kafka kafka-console-producer --bootstrap-server kafka:29092 --topic sitl-drone-home
+```
+
+Отправить:
+
+```json
+{"drone_id":"drone_901","home_lat":59.9386,"home_lon":30.3141,"home_alt":100.0}
+```
+
+Проверка:
+
+```bash
+docker compose exec redis redis-cli HGETALL drone:drone_901:state
+```
+
+Ожидаемый результат:
+
+- в `sitl.verified-home` появляется тот же JSON
+- в Redis есть `status = ARMED`
+- в Redis присутствуют `lat`, `lon`, `alt`, `home_lat`, `home_lon`, `home_alt`
+- в логах `controller` есть `Stored HOME for drone_id=drone_901`
+
+### Тест 2. Невалидный HOME отбрасывается
+
+```bash
+docker compose exec -T kafka kafka-console-producer --bootstrap-server kafka:29092 --topic sitl-drone-home
+```
+
+Отправить:
+
+```json
+{"drone_id":"drone_902","home_lat":59.9386,"home_lon":30.3141}
+```
+
+Проверка:
+
+```bash
+docker compose exec redis redis-cli HGETALL drone:drone_902:state
+```
+
+Ожидаемый результат:
+
+- в Redis для `drone_902` пусто
+- в логах `verifier` есть reject по schema validation
+
+### Тест 3. COMMAND запускает движение
+
+Терминал 1:
+
+```bash
+docker compose exec kafka kafka-console-consumer --bootstrap-server kafka:29092 --topic sitl.verified-commands --consumer-property auto.offset.reset=latest
+```
+
+Терминал 2:
+
+```bash
+docker compose exec -T kafka kafka-console-producer --bootstrap-server kafka:29092 --topic sitl.commands
+```
+
+Отправить:
+
+```json
+{"drone_id":"drone_901","vx":3.0,"vy":1.0,"vz":0.0,"mag_heading":90.0}
+```
+
+Проверка:
+
+```bash
+docker compose exec redis redis-cli HGETALL drone:drone_901:state
+```
+
+Через 1-2 секунды повторить команду `HGETALL`.
+
+Ожидаемый результат:
+
+- в `sitl.verified-commands` появляется JSON команды
+- в Redis `status = MOVING`
+- в Redis `vx = 3.0`, `vy = 1.0`, `vz = 0.0`, `mag_heading = 90.0`
+- значения `lat` и `lon` меняются между двумя чтениями
+
+### Тест 4. COMMAND без HOME игнорируется
+
+```bash
+docker compose exec -T kafka kafka-console-producer --bootstrap-server kafka:29092 --topic sitl.commands
+```
+
+Отправить:
+
+```json
+{"drone_id":"drone_903","vx":2.0,"vy":0.0,"vz":0.0,"mag_heading":45.0}
+```
+
+Проверка:
+
+```bash
+docker compose exec redis redis-cli HGETALL drone:drone_903:state
+```
+
+Ожидаемый результат:
+
+- в Redis для `drone_903` пусто
+- в логах `controller` есть `Ignored COMMAND for drone_id=drone_903: HOME state is missing`
+
+### Тест 5. messaging отвечает в reply_to
+
+Создать демонстрационный reply topic:
+
+```bash
+docker compose exec kafka kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic sitl.telemetry.response.demo1 --partitions 1 --replication-factor 1
+```
+
+Терминал 1:
+
+```bash
+docker compose exec kafka kafka-console-consumer --bootstrap-server kafka:29092 --topic sitl.telemetry.response.demo1 --consumer-property auto.offset.reset=latest --property print.headers=true
+```
+
+Терминал 2:
+
+```bash
+docker compose exec -T kafka kafka-console-producer --bootstrap-server kafka:29092 --topic sitl.telemetry.request
+```
+
+Отправить:
+
+```json
+{"drone_id":"drone_901","correlation_id":"demo-req-901","reply_to":"sitl.telemetry.response.demo1"}
+```
+
+Ожидаемый результат:
+
+- в `sitl.telemetry.response.demo1` приходит JSON с `lat`, `lon`, `alt`
+- в payload есть `correlation_id`
+- в headers ответа есть `correlation_id`
+- в логах `messaging` есть `Returned position for drone_id=drone_901`
+
+## MQTT-профиль
+
+### Запуск
+
+```bash
+make up-mqtt
+```
+
+Ожидаемый результат:
+
+- `sitl-mosquitto` в статусе `Up`
+- `sitl-redis` в статусе `Up (healthy)`
+- `sitl-verifier`, `sitl-controller`, `sitl-core`, `sitl-messaging` в статусе `Up`
+
+### Тест 1. HOME проходит через verifier и попадает в Redis
+
+Терминал 1:
+
+```bash
+docker compose exec mosquitto mosquitto_sub -h localhost -p 1883 -t sitl.verified-home
+```
+
+Терминал 2:
+
+```bash
+docker compose exec mosquitto mosquitto_pub -h localhost -p 1883 -t sitl-drone-home -m '{"drone_id":"drone_911","home_lat":59.9386,"home_lon":30.3141,"home_alt":100.0}'
+```
+
+Проверка:
+
+```bash
+docker compose exec redis redis-cli HGETALL drone:drone_911:state
+```
+
+Ожидаемый результат:
+
+- в `sitl.verified-home` приходит тот же JSON
+- в Redis есть `status = ARMED`
+
+### Тест 2. COMMAND запускает движение
+
+Терминал 1:
+
+```bash
+docker compose exec mosquitto mosquitto_sub -h localhost -p 1883 -t sitl.verified-commands
+```
+
+Терминал 2:
+
+```bash
+docker compose exec mosquitto mosquitto_pub -h localhost -p 1883 -t sitl.commands -m '{"drone_id":"drone_911","vx":3.0,"vy":1.0,"vz":0.0,"mag_heading":90.0}'
+```
+
+Проверка:
+
+```bash
+docker compose exec redis redis-cli HGETALL drone:drone_911:state
+```
+
+Через 1-2 секунды повторить `HGETALL`.
+
+Ожидаемый результат:
+
+- в `sitl.verified-commands` приходит JSON команды
+- в Redis `status = MOVING`
+- `lat` и `lon` меняются между чтениями
+
+### Тест 3. messaging отвечает в MQTT reply_to
+
+Терминал 1:
+
+```bash
+docker compose exec mosquitto mosquitto_sub -h localhost -p 1883 -t sitl.telemetry.response.demo2
+```
+
+Терминал 2:
+
+```bash
+docker compose exec mosquitto mosquitto_pub -h localhost -p 1883 -t sitl.telemetry.request -m '{"drone_id":"drone_911","correlation_id":"demo-req-911","reply_to":"sitl.telemetry.response.demo2"}'
+```
+
+Ожидаемый результат:
+
+- в `sitl.telemetry.response.demo2` приходит JSON с `lat`, `lon`, `alt`
+- в payload ответа есть `correlation_id = "demo-req-911"`
+- в логах `messaging` есть `Returned position for drone_id=drone_911`
+
+### Тест 4. messaging не отвечает для неизвестного дрона
+
+Терминал 1:
+
+```bash
+docker compose exec mosquitto mosquitto_sub -h localhost -p 1883 -t sitl.telemetry.response.demo3 -W 5
+```
+
+Терминал 2:
+
+```bash
+docker compose exec mosquitto mosquitto_pub -h localhost -p 1883 -t sitl.telemetry.request -m '{"drone_id":"drone_999","correlation_id":"demo-req-999","reply_to":"sitl.telemetry.response.demo3"}'
+```
+
+Ожидаемый результат:
+
+- в `sitl.telemetry.response.demo3` ответ не приходит
+- в логах `messaging` есть reject с текстом `state not found`

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -1,0 +1,3 @@
+listener 1883 0.0.0.0
+allow_anonymous true
+persistence false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiokafka==0.11.0
+aiomqtt==2.3.0
 jsonschema==4.23.0
 redis==5.0.1
 pytest==8.3.3

--- a/schemas/sitl-position-request.json
+++ b/schemas/sitl-position-request.json
@@ -7,6 +7,14 @@
     "drone_id": {
       "type": "string",
       "pattern": "^drone_[0-9]{3,4}$"
+    },
+    "correlation_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reply_to": {
+      "type": "string",
+      "minLength": 1
     }
   }
 }

--- a/schemas/sitl-position-response.json
+++ b/schemas/sitl-position-response.json
@@ -12,6 +12,10 @@
     },
     "alt": {
       "type": "number"
+    },
+    "correlation_id": {
+      "type": "string",
+      "minLength": 1
     }
   }
 }

--- a/src/broker.py
+++ b/src/broker.py
@@ -1,0 +1,319 @@
+import asyncio
+import json
+import logging
+import os
+from abc import ABC
+from abc import abstractmethod
+from collections.abc import AsyncIterator
+from collections.abc import Mapping
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+from typing import Callable
+
+import aiomqtt
+from aiokafka import AIOKafkaConsumer
+from aiokafka import AIOKafkaProducer
+
+DEFAULT_BROKER_BACKEND = "kafka"
+DEFAULT_KAFKA_SERVERS = "kafka:9092"
+DEFAULT_MQTT_HOST = "mosquitto"
+DEFAULT_MQTT_PORT = 1883
+DEFAULT_MQTT_QOS = 1
+RETRY_DELAYS_SEC = (1.0, 2.0, 4.0, 8.0, 10.0)
+
+
+@dataclass(frozen=True)
+class BrokerMessage:
+    topic: str
+    payload: Any
+    headers: list[tuple[str, bytes]] | None = None
+
+
+@dataclass(frozen=True)
+class BrokerSettings:
+    backend: str
+    kafka_servers: str
+    mqtt_host: str
+    mqtt_port: int
+    mqtt_username: str | None
+    mqtt_password: str | None
+    mqtt_qos: int
+
+
+def _blank_to_none(value: str) -> str | None:
+    stripped = value.strip()
+    return stripped or None
+
+
+def load_broker_settings_from_env(env: Mapping[str, str] | None = None) -> BrokerSettings:
+    source = env if env is not None else os.environ
+    backend = source.get("BROKER_BACKEND", DEFAULT_BROKER_BACKEND).strip().lower() or DEFAULT_BROKER_BACKEND
+    if backend not in {"kafka", "mqtt"}:
+        raise ValueError(f"unsupported BROKER_BACKEND '{backend}'")
+
+    mqtt_port = int(source.get("MQTT_PORT", str(DEFAULT_MQTT_PORT)))
+    mqtt_qos = int(source.get("MQTT_QOS", str(DEFAULT_MQTT_QOS)))
+    if mqtt_qos not in {0, 1, 2}:
+        raise ValueError(f"unsupported MQTT_QOS '{mqtt_qos}'")
+
+    return BrokerSettings(
+        backend=backend,
+        kafka_servers=source.get("KAFKA_SERVERS", DEFAULT_KAFKA_SERVERS).strip() or DEFAULT_KAFKA_SERVERS,
+        mqtt_host=source.get("MQTT_HOST", DEFAULT_MQTT_HOST).strip() or DEFAULT_MQTT_HOST,
+        mqtt_port=mqtt_port,
+        mqtt_username=_blank_to_none(source.get("MQTT_USERNAME", "")),
+        mqtt_password=_blank_to_none(source.get("MQTT_PASSWORD", "")),
+        mqtt_qos=mqtt_qos,
+    )
+
+
+class BrokerClient(ABC):
+    @abstractmethod
+    async def start(self) -> None:
+        pass
+
+    @abstractmethod
+    async def stop(self) -> None:
+        pass
+
+    @abstractmethod
+    async def publish(
+        self,
+        topic: str,
+        payload: dict[str, Any],
+        headers: list[tuple[str, bytes]] | None = None,
+    ) -> None:
+        pass
+
+    @abstractmethod
+    def iter_messages(
+        self,
+        topics: Sequence[str],
+        group_id: str | None = None,
+    ) -> AsyncIterator[BrokerMessage]:
+        pass
+
+
+class KafkaBrokerClient(BrokerClient):
+    def __init__(
+        self,
+        kafka_servers: str,
+        producer_factory: Callable[..., Any] = AIOKafkaProducer,
+        consumer_factory: Callable[..., Any] = AIOKafkaConsumer,
+    ) -> None:
+        self.kafka_servers = kafka_servers
+        self._producer_factory = producer_factory
+        self._consumer_factory = consumer_factory
+        self._producer: Any | None = None
+
+    async def start(self) -> None:
+        if self._producer is not None:
+            return
+
+        self._producer = self._producer_factory(
+            bootstrap_servers=self.kafka_servers,
+            value_serializer=lambda value: json.dumps(value).encode(),
+        )
+        try:
+            await self._producer.start()
+        except Exception:
+            self._producer = None
+            raise
+
+    async def stop(self) -> None:
+        if self._producer is None:
+            return
+
+        producer = self._producer
+        self._producer = None
+        await producer.stop()
+
+    async def publish(
+        self,
+        topic: str,
+        payload: dict[str, Any],
+        headers: list[tuple[str, bytes]] | None = None,
+    ) -> None:
+        if self._producer is None:
+            raise RuntimeError("KafkaBrokerClient must be started before publish")
+
+        await self._producer.send_and_wait(topic, payload, headers=headers)
+
+    async def _iter_consumer_messages(
+        self,
+        topics: Sequence[str],
+        group_id: str | None = None,
+    ) -> AsyncIterator[BrokerMessage]:
+        consumer = self._consumer_factory(
+            *topics,
+            bootstrap_servers=self.kafka_servers,
+            group_id=group_id,
+        )
+        started = False
+        try:
+            await consumer.start()
+            started = True
+            async for message in consumer:
+                yield BrokerMessage(
+                    topic=message.topic,
+                    payload=message.value,
+                    headers=message.headers,
+                )
+        finally:
+            if started:
+                await consumer.stop()
+
+    def iter_messages(
+        self,
+        topics: Sequence[str],
+        group_id: str | None = None,
+    ) -> AsyncIterator[BrokerMessage]:
+        return self._iter_consumer_messages(topics, group_id=group_id)
+
+
+class MqttBrokerClient(BrokerClient):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        username: str | None = None,
+        password: str | None = None,
+        qos: int = DEFAULT_MQTT_QOS,
+        client_factory: Callable[..., Any] = aiomqtt.Client,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.qos = qos
+        self._client_factory = client_factory
+        self._client: Any | None = None
+
+    async def start(self) -> None:
+        if self._client is not None:
+            return
+
+        client = self._client_factory(
+            hostname=self.host,
+            port=self.port,
+            username=self.username,
+            password=self.password,
+        )
+        try:
+            await client.__aenter__()
+        except Exception:
+            raise
+        self._client = client
+
+    async def stop(self) -> None:
+        if self._client is None:
+            return
+
+        client = self._client
+        self._client = None
+        await client.__aexit__(None, None, None)
+
+    async def publish(
+        self,
+        topic: str,
+        payload: dict[str, Any],
+        headers: list[tuple[str, bytes]] | None = None,
+    ) -> None:
+        del headers
+        if self._client is None:
+            raise RuntimeError("MqttBrokerClient must be started before publish")
+
+        await self._client.publish(
+            topic,
+            payload=json.dumps(payload),
+            qos=self.qos,
+            retain=False,
+        )
+
+    async def _iter_client_messages(
+        self,
+        topics: Sequence[str],
+        group_id: str | None = None,
+    ) -> AsyncIterator[BrokerMessage]:
+        del group_id
+        if self._client is None:
+            raise RuntimeError("MqttBrokerClient must be started before iter_messages")
+
+        for topic in topics:
+            await self._client.subscribe(topic, qos=self.qos)
+
+        async for message in self._client.messages:
+            yield BrokerMessage(
+                topic=str(message.topic),
+                payload=message.payload,
+                headers=None,
+            )
+
+    def iter_messages(
+        self,
+        topics: Sequence[str],
+        group_id: str | None = None,
+    ) -> AsyncIterator[BrokerMessage]:
+        return self._iter_client_messages(topics, group_id=group_id)
+
+
+def create_broker_client(settings: BrokerSettings) -> BrokerClient:
+    if settings.backend == "kafka":
+        return KafkaBrokerClient(settings.kafka_servers)
+    if settings.backend == "mqtt":
+        return MqttBrokerClient(
+            settings.mqtt_host,
+            settings.mqtt_port,
+            username=settings.mqtt_username,
+            password=settings.mqtt_password,
+            qos=settings.mqtt_qos,
+        )
+    raise ValueError(f"unsupported BROKER_BACKEND '{settings.backend}'")
+
+
+def create_broker_client_from_env(env: Mapping[str, str] | None = None) -> BrokerClient:
+    return create_broker_client(load_broker_settings_from_env(env))
+
+
+def _next_retry_delay(current_delay: float) -> float:
+    for delay in RETRY_DELAYS_SEC:
+        if delay > current_delay:
+            return delay
+    return RETRY_DELAYS_SEC[-1]
+
+
+async def start_broker_with_retry(
+    client: BrokerClient,
+    log: logging.Logger,
+    label: str,
+) -> None:
+    delay = RETRY_DELAYS_SEC[0]
+    while True:
+        try:
+            await client.start()
+            return
+        except Exception as exc:
+            log.warning("%s unavailable: %s. Retrying in %.0fs", label, exc, delay)
+            await asyncio.sleep(delay)
+            delay = _next_retry_delay(delay)
+
+
+async def iter_broker_messages_with_retry(
+    client: BrokerClient,
+    topics: Sequence[str],
+    log: logging.Logger,
+    label: str,
+    group_id: str | None = None,
+) -> AsyncIterator[BrokerMessage]:
+    delay = RETRY_DELAYS_SEC[0]
+    while True:
+        try:
+            async for message in client.iter_messages(topics, group_id=group_id):
+                delay = RETRY_DELAYS_SEC[0]
+                yield message
+            return
+        except Exception as exc:
+            log.warning("%s subscription unavailable: %s. Retrying in %.0fs", label, exc, delay)
+            await asyncio.sleep(delay)
+            delay = _next_retry_delay(delay)

--- a/src/contracts.py
+++ b/src/contracts.py
@@ -14,7 +14,6 @@ HOME_SCHEMA_NAME = "sitl-drone-home.json"
 POSITION_REQUEST_SCHEMA_NAME = "sitl-position-request.json"
 POSITION_RESPONSE_SCHEMA_NAME = "sitl-position-response.json"
 VERIFIER_STAGE = "SITL-v1"
-TRANSPORT_FIELDS = frozenset({"correlation_id", "reply_to"})
 SCHEMAS_DIR = Path(__file__).resolve().parents[1] / "schemas"
 VERIFIED_COMMAND_TOPIC_DEFAULT = "sitl.verified-commands"
 VERIFIED_HOME_TOPIC_DEFAULT = "sitl.verified-home"
@@ -54,14 +53,6 @@ def get_validator(schema_name: str) -> Draft202012Validator:
     return Draft202012Validator(load_schema(schema_name))
 
 
-def strip_transport_fields(payload: dict[str, Any]) -> dict[str, Any]:
-    return {
-        key: value
-        for key, value in payload.items()
-        if key not in TRANSPORT_FIELDS
-    }
-
-
 def format_validation_error(schema_name: str, errors: Iterable[Any]) -> str:
     first_error = sorted(errors, key=lambda item: list(item.absolute_path))[0]
     path = ".".join(str(part) for part in first_error.absolute_path) or "$"
@@ -71,10 +62,8 @@ def format_validation_error(schema_name: str, errors: Iterable[Any]) -> str:
 def validate_schema(
     payload: dict[str, Any],
     schema_name: str,
-    allow_transport_fields: bool = False,
 ) -> Tuple[bool, str]:
-    candidate = strip_transport_fields(payload) if allow_transport_fields else payload
-    errors = list(get_validator(schema_name).iter_errors(candidate))
+    errors = list(get_validator(schema_name).iter_errors(payload))
     if errors:
         return False, format_validation_error(schema_name, errors)
     return True, ""

--- a/src/controller.py
+++ b/src/controller.py
@@ -4,10 +4,11 @@ import os
 from typing import Any
 
 import redis.asyncio as redis
-from aiokafka import AIOKafkaConsumer
+from broker import create_broker_client_from_env
+from broker import iter_broker_messages_with_retry
+from broker import start_broker_with_retry
 
 from contracts import classify_input_topic
-from contracts import HOME_SCHEMA_NAME
 from contracts import parse_json_payload
 from contracts import validate_schema
 from contracts import VERIFIED_COMMAND_TOPIC_DEFAULT
@@ -86,7 +87,6 @@ async def process_verified_message(
 
 async def main() -> None:
     redis_url = os.getenv("REDIS_URL", "redis://redis:6379")
-    kafka_servers = os.getenv("KAFKA_SERVERS", "kafka:9092")
     verified_commands_topic = os.getenv(
         "VERIFIED_COMMAND_TOPIC",
         VERIFIED_COMMAND_TOPIC_DEFAULT,
@@ -101,13 +101,9 @@ async def main() -> None:
     ]
     state_ttl_sec = int(os.getenv("STATE_TTL_SEC", "7200"))
     r = redis.from_url(redis_url, decode_responses=True)
-    consumer = AIOKafkaConsumer(
-        *input_topics,
-        bootstrap_servers=kafka_servers,
-        group_id="SITL-controller-v1",
-    )
+    broker = create_broker_client_from_env()
+    await start_broker_with_retry(broker, log, "Controller broker")
 
-    await consumer.start()
     log.info(
         "Controller started. input_topics=%s redis=%s",
         input_topics,
@@ -115,8 +111,14 @@ async def main() -> None:
     )
 
     try:
-        async for msg in consumer:
-            payload = parse_json_payload(msg.value)
+        async for msg in iter_broker_messages_with_retry(
+            broker,
+            input_topics,
+            log,
+            "Controller broker",
+            group_id="SITL-controller-v1",
+        ):
+            payload = parse_json_payload(msg.payload)
             if payload is None:
                 log.warning("Rejected message from topic=%s: invalid JSON payload", msg.topic)
                 continue
@@ -130,7 +132,7 @@ async def main() -> None:
                 state_ttl_sec,
             )
     finally:
-        await consumer.stop()
+        await broker.stop()
         await r.aclose()
 
 

--- a/src/messaging.py
+++ b/src/messaging.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 from abc import ABC
@@ -10,8 +9,10 @@ from typing import Optional
 
 import asyncio
 import redis.asyncio as redis
-from aiokafka import AIOKafkaConsumer
-from aiokafka import AIOKafkaProducer
+from broker import BrokerClient
+from broker import create_broker_client_from_env
+from broker import iter_broker_messages_with_retry
+from broker import start_broker_with_retry
 
 from contracts import build_request_headers
 from contracts import decode_headers
@@ -50,11 +51,7 @@ async def resolve_position_request(
     r: redis.Redis,
     payload: dict[str, Any],
 ) -> tuple[dict[str, float] | None, str]:
-    ok, reason = validate_schema(
-        payload,
-        POSITION_REQUEST_SCHEMA_NAME,
-        allow_transport_fields=True,
-    )
+    ok, reason = validate_schema(payload, POSITION_REQUEST_SCHEMA_NAME)
     if not ok:
         return None, reason
 
@@ -82,7 +79,7 @@ async def handle_position_request(
 
 
 async def dispatch_request_message(
-    producer: Any,
+    publisher: Any,
     raw_payload: Any,
     raw_headers: list[tuple[str, bytes]] | None,
     handler: RequestHandler,
@@ -101,37 +98,31 @@ async def dispatch_request_message(
     if response is None:
         return False, "handler returned no response", drone_id
 
-    ok, reason = validate_schema(response, POSITION_RESPONSE_SCHEMA_NAME)
+    response_payload = dict(response)
+    if correlation_id:
+        response_payload["correlation_id"] = correlation_id
+
+    ok, reason = validate_schema(response_payload, POSITION_RESPONSE_SCHEMA_NAME)
     if not ok:
         return False, reason, drone_id
 
     response_headers = build_request_headers(correlation_id, reply_to) if correlation_id else None
-    await producer.send_and_wait(
+    await publisher.publish(
         reply_to,
-        response,
+        response_payload,
         headers=response_headers,
     )
     return True, reply_to, drone_id
 
 
-class KafkaRequestResponder(RequestResponder):
+class BrokerRequestResponder(RequestResponder):
     def __init__(
         self,
-        kafka_servers: str,
+        broker: BrokerClient,
         consumer_group_id: str = "SITL-position-service-v1",
     ) -> None:
-        self.kafka_servers = kafka_servers
+        self.broker = broker
         self.consumer_group_id = consumer_group_id
-        self._producer = AIOKafkaProducer(
-            bootstrap_servers=kafka_servers,
-            value_serializer=lambda value: json.dumps(value).encode(),
-        )
-
-    async def start(self) -> None:
-        await self._producer.start()
-
-    async def stop(self) -> None:
-        await self._producer.stop()
 
     async def serve(
         self,
@@ -139,14 +130,7 @@ class KafkaRequestResponder(RequestResponder):
         handler: RequestHandler,
         default_response_topic: str,
     ) -> None:
-        consumer = AIOKafkaConsumer(
-            topic,
-            bootstrap_servers=self.kafka_servers,
-            group_id=self.consumer_group_id,
-        )
-
-        await self.start()
-        await consumer.start()
+        await start_broker_with_retry(self.broker, log, "Messaging broker")
         log.info(
             "Request responder started. request_topic=%s response_topic=%s",
             topic,
@@ -154,11 +138,17 @@ class KafkaRequestResponder(RequestResponder):
         )
 
         try:
-            async for msg in consumer:
+            async for msg in iter_broker_messages_with_retry(
+                self.broker,
+                [topic],
+                log,
+                "Messaging broker",
+                group_id=self.consumer_group_id,
+            ):
                 try:
                     ok, detail, drone_id = await dispatch_request_message(
-                        self._producer,
-                        msg.value,
+                        self.broker,
+                        msg.payload,
                         msg.headers,
                         handler,
                         default_response_topic,
@@ -175,22 +165,20 @@ class KafkaRequestResponder(RequestResponder):
                 except Exception as exc:
                     log.error("Failed to process request from topic=%s: %s", msg.topic, exc, exc_info=True)
         finally:
-            await consumer.stop()
-            await self.stop()
+            await self.broker.stop()
 
 
 async def main() -> None:
     redis_url = os.getenv("REDIS_URL", "redis://redis:6379")
-    kafka_servers = os.getenv("KAFKA_SERVERS", "kafka:9092")
     request_topic = os.getenv("POSITION_REQUEST_TOPIC", POSITION_REQUEST_TOPIC_DEFAULT)
     response_topic = os.getenv("POSITION_RESPONSE_TOPIC", POSITION_RESPONSE_TOPIC_DEFAULT)
     r = redis.from_url(redis_url, decode_responses=True)
-    responder = KafkaRequestResponder(kafka_servers)
+    broker = create_broker_client_from_env()
+    responder = BrokerRequestResponder(broker)
 
     log.info(
-        "Messaging started. redis=%s kafka=%s request_topic=%s",
+        "Messaging started. redis=%s request_topic=%s",
         redis_url,
-        kafka_servers,
         request_topic,
     )
 

--- a/src/verifier.py
+++ b/src/verifier.py
@@ -1,11 +1,11 @@
 import asyncio
-import json
 import logging
 import os
 from typing import Any
 
-from aiokafka import AIOKafkaConsumer
-from aiokafka import AIOKafkaProducer
+from broker import create_broker_client_from_env
+from broker import iter_broker_messages_with_retry
+from broker import start_broker_with_retry
 
 from contracts import classify_input_topic
 from contracts import parse_json_payload
@@ -49,7 +49,6 @@ def process_input_message(
 
 
 async def main() -> None:
-    kafka_servers = os.getenv("KAFKA_SERVERS", "kafka:9092")
     commands_topic = os.getenv("COMMAND_TOPIC", "sitl.commands")
     home_topic = os.getenv("HOME_TOPIC", "sitl-drone-home")
     input_topics = parse_csv_env("INPUT_TOPICS", f"{commands_topic},{home_topic}")
@@ -65,18 +64,9 @@ async def main() -> None:
     if not input_topics:
         raise RuntimeError("INPUT_TOPICS cannot be empty")
 
-    producer = AIOKafkaProducer(
-        bootstrap_servers=kafka_servers,
-        value_serializer=lambda value: json.dumps(value).encode(),
-    )
-    consumer = AIOKafkaConsumer(
-        *input_topics,
-        bootstrap_servers=kafka_servers,
-        group_id="SITL-verifier-v1",
-    )
+    broker = create_broker_client_from_env()
 
-    await producer.start()
-    await consumer.start()
+    await start_broker_with_retry(broker, log, "Verifier broker")
     log.info(
         "Verifier started. input=%s verified_commands=%s verified_home=%s",
         input_topics,
@@ -85,10 +75,16 @@ async def main() -> None:
     )
 
     try:
-        async for msg in consumer:
+        async for msg in iter_broker_messages_with_retry(
+            broker,
+            input_topics,
+            log,
+            "Verifier broker",
+            group_id="SITL-verifier-v1",
+        ):
             ok, message_type, payload, reason = process_input_message(
                 msg.topic,
-                msg.value,
+                msg.payload,
                 commands_topic,
                 home_topic,
             )
@@ -101,7 +97,7 @@ async def main() -> None:
                 verified_commands_topic,
                 verified_home_topic,
             )
-            await producer.send_and_wait(output_topic, payload)
+            await broker.publish(output_topic, payload)
             log.info(
                 "Verified message_type=%s drone_id=%s output_topic=%s",
                 message_type,
@@ -109,8 +105,7 @@ async def main() -> None:
                 output_topic,
             )
     finally:
-        await producer.stop()
-        await consumer.stop()
+        await broker.stop()
 
 
 if __name__ == "__main__":

--- a/tests/test_broker_unit.py
+++ b/tests/test_broker_unit.py
@@ -1,0 +1,280 @@
+import asyncio
+import pathlib
+import sys
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import broker  # type: ignore  # noqa: E402
+
+
+class FakeKafkaProducer:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.started = False
+        self.stopped = False
+        self.sent_messages: list[dict[str, Any]] = []
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def send_and_wait(
+        self,
+        topic: str,
+        value: dict[str, Any],
+        headers: list[tuple[str, bytes]] | None = None,
+    ) -> None:
+        self.sent_messages.append(
+            {
+                "topic": topic,
+                "value": value,
+                "headers": headers,
+            }
+        )
+
+
+class FakeKafkaMessage:
+    def __init__(
+        self,
+        topic: str,
+        value: bytes,
+        headers: list[tuple[str, bytes]] | None = None,
+    ) -> None:
+        self.topic = topic
+        self.value = value
+        self.headers = headers
+
+
+class FakeKafkaConsumer:
+    def __init__(self, *topics: str, messages: list[FakeKafkaMessage], **kwargs: Any) -> None:
+        self.topics = topics
+        self.kwargs = kwargs
+        self.started = False
+        self.stopped = False
+        self._messages = list(messages)
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    def __aiter__(self) -> "FakeKafkaConsumer":
+        return self
+
+    async def __anext__(self) -> FakeKafkaMessage:
+        if not self._messages:
+            raise StopAsyncIteration
+        return self._messages.pop(0)
+
+
+class FakeMqttMessage:
+    def __init__(self, topic: str, payload: bytes) -> None:
+        self.topic = topic
+        self.payload = payload
+
+
+class FakeAsyncMessageStream:
+    def __init__(self, messages: list[FakeMqttMessage]) -> None:
+        self._messages = list(messages)
+
+    def __aiter__(self) -> "FakeAsyncMessageStream":
+        return self
+
+    async def __anext__(self) -> FakeMqttMessage:
+        if not self._messages:
+            raise StopAsyncIteration
+        return self._messages.pop(0)
+
+
+class FakeMqttClient:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.entered = False
+        self.exited = False
+        self.subscriptions: list[tuple[str, int]] = []
+        self.published: list[dict[str, Any]] = []
+        self.messages = FakeAsyncMessageStream(
+            [
+                FakeMqttMessage(
+                    "sitl.commands",
+                    b'{"drone_id":"drone_001","vx":1.0,"vy":0.0,"vz":0.0,"mag_heading":45.0}',
+                )
+            ]
+        )
+
+    async def __aenter__(self) -> "FakeMqttClient":
+        self.entered = True
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.exited = True
+
+    async def subscribe(self, topic: str, qos: int) -> None:
+        self.subscriptions.append((topic, qos))
+
+    async def publish(self, topic: str, payload: str, qos: int, retain: bool) -> None:
+        self.published.append(
+            {
+                "topic": topic,
+                "payload": payload,
+                "qos": qos,
+                "retain": retain,
+            }
+        )
+
+
+def test_load_broker_settings_defaults_to_kafka() -> None:
+    settings = broker.load_broker_settings_from_env({})
+
+    assert settings.backend == "kafka"
+    assert settings.kafka_servers == "kafka:9092"
+    assert settings.mqtt_host == "mosquitto"
+    assert settings.mqtt_port == 1883
+    assert settings.mqtt_qos == 1
+
+
+def test_load_broker_settings_rejects_unknown_backend() -> None:
+    try:
+        broker.load_broker_settings_from_env({"BROKER_BACKEND": "nats"})
+    except ValueError as exc:
+        assert "unsupported BROKER_BACKEND" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for unsupported broker backend")
+
+
+def test_create_broker_client_from_env_returns_mqtt_client() -> None:
+    client = broker.create_broker_client_from_env(
+        {
+            "BROKER_BACKEND": "mqtt",
+            "MQTT_HOST": "mqtt.local",
+            "MQTT_PORT": "1884",
+            "MQTT_QOS": "1",
+        }
+    )
+
+    assert isinstance(client, broker.MqttBrokerClient)
+
+
+def test_kafka_broker_client_publishes_and_reads_messages() -> None:
+    async def scenario() -> None:
+        captured: dict[str, Any] = {}
+
+        def producer_factory(**kwargs: Any) -> FakeKafkaProducer:
+            producer = FakeKafkaProducer(**kwargs)
+            captured["producer"] = producer
+            return producer
+
+        def consumer_factory(*topics: str, **kwargs: Any) -> FakeKafkaConsumer:
+            consumer = FakeKafkaConsumer(
+                *topics,
+                messages=[
+                    FakeKafkaMessage(
+                        "sitl.commands",
+                        b'{"drone_id":"drone_001"}',
+                        headers=[("correlation_id", b"req-1")],
+                    )
+                ],
+                **kwargs,
+            )
+            captured["consumer"] = consumer
+            return consumer
+
+        client = broker.KafkaBrokerClient(
+            "kafka:29092",
+            producer_factory=producer_factory,
+            consumer_factory=consumer_factory,
+        )
+
+        await client.start()
+        await client.publish(
+            "sitl.verified-home",
+            {"drone_id": "drone_001"},
+            headers=[("correlation_id", b"req-1")],
+        )
+
+        messages: list[broker.BrokerMessage] = []
+        async for message in client.iter_messages(["sitl.commands"], group_id="group-1"):
+            messages.append(message)
+
+        await client.stop()
+
+        producer = captured["producer"]
+        consumer = captured["consumer"]
+        assert producer.started is True
+        assert producer.stopped is True
+        assert producer.sent_messages == [
+            {
+                "topic": "sitl.verified-home",
+                "value": {"drone_id": "drone_001"},
+                "headers": [("correlation_id", b"req-1")],
+            }
+        ]
+        assert consumer.started is True
+        assert consumer.stopped is True
+        assert consumer.topics == ("sitl.commands",)
+        assert consumer.kwargs["group_id"] == "group-1"
+        assert messages == [
+            broker.BrokerMessage(
+                topic="sitl.commands",
+                payload=b'{"drone_id":"drone_001"}',
+                headers=[("correlation_id", b"req-1")],
+            )
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_mqtt_broker_client_publishes_and_reads_messages() -> None:
+    async def scenario() -> None:
+        captured: dict[str, Any] = {}
+
+        def client_factory(**kwargs: Any) -> FakeMqttClient:
+            client = FakeMqttClient(**kwargs)
+            captured["client"] = client
+            return client
+
+        client = broker.MqttBrokerClient(
+            "mosquitto",
+            1883,
+            qos=1,
+            client_factory=client_factory,
+        )
+
+        await client.start()
+        await client.publish("sitl.telemetry.response", {"lat": 1.0, "lon": 2.0, "alt": 3.0})
+
+        messages: list[broker.BrokerMessage] = []
+        async for message in client.iter_messages(["sitl.commands"]):
+            messages.append(message)
+
+        await client.stop()
+
+        mqtt_client = captured["client"]
+        assert mqtt_client.entered is True
+        assert mqtt_client.exited is True
+        assert mqtt_client.subscriptions == [("sitl.commands", 1)]
+        assert mqtt_client.published == [
+            {
+                "topic": "sitl.telemetry.response",
+                "payload": '{"lat": 1.0, "lon": 2.0, "alt": 3.0}',
+                "qos": 1,
+                "retain": False,
+            }
+        ]
+        assert messages == [
+            broker.BrokerMessage(
+                topic="sitl.commands",
+                payload=b'{"drone_id":"drone_001","vx":1.0,"vy":0.0,"vz":0.0,"mag_heading":45.0}',
+                headers=None,
+            )
+        ]
+
+    asyncio.run(scenario())

--- a/tests/test_controller_unit.py
+++ b/tests/test_controller_unit.py
@@ -16,8 +16,8 @@ import state  # type: ignore  # noqa: E402
 from fakes import FakeRedis  # type: ignore  # noqa: E402
 
 
-VERIFIED_COMMAND_TOPIC = "sitl-verified-commands"
-VERIFIED_HOME_TOPIC = "sitl-verified-home"
+VERIFIED_COMMAND_TOPIC = "sitl.verified-commands"
+VERIFIED_HOME_TOPIC = "sitl.verified-home"
 STATE_TTL_SEC = 7200
 
 

--- a/tests/test_flow_unit.py
+++ b/tests/test_flow_unit.py
@@ -17,10 +17,10 @@ import verifier  # type: ignore  # noqa: E402
 from fakes import FakeRedis  # type: ignore  # noqa: E402
 
 
-COMMAND_TOPIC = "sitl-commands"
+COMMAND_TOPIC = "sitl.commands"
 HOME_TOPIC = "sitl-drone-home"
-VERIFIED_COMMAND_TOPIC = "sitl-verified-commands"
-VERIFIED_HOME_TOPIC = "sitl-verified-home"
+VERIFIED_COMMAND_TOPIC = "sitl.verified-commands"
+VERIFIED_HOME_TOPIC = "sitl.verified-home"
 
 
 def test_end_to_end_flow_from_verifier_to_position_response() -> None:

--- a/tests/test_messaging_unit.py
+++ b/tests/test_messaging_unit.py
@@ -21,7 +21,7 @@ class FakeProducer:
     def __init__(self) -> None:
         self.sent_messages: list[dict[str, Any]] = []
 
-    async def send_and_wait(
+    async def publish(
         self,
         topic: str,
         value: dict[str, Any],
@@ -56,7 +56,7 @@ def test_dispatch_request_message_sends_response_to_reply_topic() -> None:
                 ("reply_to", b"custom-position-response"),
             ],
             handler,
-            "sitl-position-response",
+            "sitl.telemetry.response",
         )
 
         assert ok is True
@@ -69,10 +69,61 @@ def test_dispatch_request_message_sends_response_to_reply_topic() -> None:
                     "lat": 59.9386,
                     "lon": 30.3141,
                     "alt": 120.0,
+                    "correlation_id": "req-123",
                 },
                 "headers": [
                     ("correlation_id", b"req-123"),
                     ("reply_to", b"custom-position-response"),
+                ],
+            }
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_dispatch_request_message_accepts_transport_metadata_from_payload() -> None:
+    async def scenario() -> None:
+        producer = FakeProducer()
+
+        async def handler(payload: dict[str, Any]) -> dict[str, Any] | None:
+            assert payload == {
+                "drone_id": "drone_001",
+                "correlation_id": "req-456",
+                "reply_to": "mqtt-position-response",
+            }
+            return {
+                "lat": 59.9386,
+                "lon": 30.3141,
+                "alt": 120.0,
+            }
+
+        ok, detail, drone_id = await messaging.dispatch_request_message(
+            producer,
+            {
+                "drone_id": "drone_001",
+                "correlation_id": "req-456",
+                "reply_to": "mqtt-position-response",
+            },
+            None,
+            handler,
+            "sitl.telemetry.response",
+        )
+
+        assert ok is True
+        assert detail == "mqtt-position-response"
+        assert drone_id == "drone_001"
+        assert producer.sent_messages == [
+            {
+                "topic": "mqtt-position-response",
+                "value": {
+                    "lat": 59.9386,
+                    "lon": 30.3141,
+                    "alt": 120.0,
+                    "correlation_id": "req-456",
+                },
+                "headers": [
+                    ("correlation_id", b"req-456"),
+                    ("reply_to", b"mqtt-position-response"),
                 ],
             }
         ]
@@ -95,7 +146,7 @@ def test_dispatch_request_message_rejects_invalid_response_shape() -> None:
             {"drone_id": "drone_001"},
             None,
             handler,
-            "sitl-position-response",
+            "sitl.telemetry.response",
         )
 
         assert ok is False

--- a/tests/test_verifier_unit.py
+++ b/tests/test_verifier_unit.py
@@ -12,10 +12,10 @@ import contracts  # type: ignore  # noqa: E402
 import verifier  # type: ignore  # noqa: E402
 
 
-COMMAND_TOPIC = "sitl-commands"
+COMMAND_TOPIC = "sitl.commands"
 HOME_TOPIC = "sitl-drone-home"
-VERIFIED_COMMAND_TOPIC = "sitl-verified-commands"
-VERIFIED_HOME_TOPIC = "sitl-verified-home"
+VERIFIED_COMMAND_TOPIC = "sitl.verified-commands"
+VERIFIED_HOME_TOPIC = "sitl.verified-home"
 
 
 def test_parse_json_payload_accepts_dict_bytes_and_string() -> None:


### PR DESCRIPTION
Реализована поддержка двух брокеров сообщений с выбором через конфиг: добавлен общий transport layer для Kafka и MQTT, на него переведены `verifier`, `controller` и `messaging`, обновлены request/response-схемы для `reply_to` и `correlation_id`. Также обновлены `docker-compose` и `Makefile` под два режима запуска, добавлены тесты для broker abstraction и обновлены ручные проверки и архитектурная документация.